### PR TITLE
feat: eliminate the impact caused by l2-reorg by scanning finalized blocks only

### DIFF
--- a/cmd/bot/run.go
+++ b/cmd/bot/run.go
@@ -59,7 +59,7 @@ func RunCommand(ctx *cli.Context) error {
 		return fmt.Errorf("failed to migrate l2_contract_events: %w", err)
 	}
 
-	l2ScannedBlock, err := queryL2ScannedBlock(db, &cfg)
+	l2ScannedBlock, err := queryL2ScannedBlock(db)
 	if err != nil {
 		return err
 	}
@@ -213,16 +213,13 @@ func WatchBotDelegatedWithdrawals(ctx context.Context, log log.Logger, db *gorm.
 		}
 
 		toBlockNumber := new(big.Int).Add(fromBlockNumber, big.NewInt(cfg.Misc.LogFilterBlockRange))
-		latestNumber, err := client.BlockNumber(context.Background())
+		finalizedHeader, err := client.GetHeaderByTag(context.Background(), "finalized")
 		if err != nil {
 			log.Error("call eth_blockNumber", "error", err)
 			continue
 		}
-
-		if latestNumber < uint64(cfg.Misc.ConfirmBlocks) {
-			toBlockNumber = big.NewInt(0)
-		} else if latestNumber-uint64(cfg.Misc.ConfirmBlocks) < toBlockNumber.Uint64() {
-			toBlockNumber = big.NewInt(int64(latestNumber - uint64(cfg.Misc.ConfirmBlocks)))
+		if toBlockNumber.Uint64() > finalizedHeader.Number.Uint64() {
+			toBlockNumber = finalizedHeader.Number
 		}
 
 		if fromBlockNumber.Uint64() > toBlockNumber.Uint64() {
@@ -314,7 +311,7 @@ func connect(log log.Logger, dbConfig config.DBConfig) (*gorm.DB, error) {
 }
 
 // queryL2ScannedBlock queries the l2_scanned_blocks table for the last scanned block
-func queryL2ScannedBlock(db *gorm.DB, cfg *core.Config) (*core.L2ScannedBlock, error) {
+func queryL2ScannedBlock(db *gorm.DB) (*core.L2ScannedBlock, error) {
 	l2ScannedBlock := core.L2ScannedBlock{Number: 0}
 	result := db.Order("number desc").Last(&l2ScannedBlock)
 	if result.Error != nil {
@@ -322,12 +319,6 @@ func queryL2ScannedBlock(db *gorm.DB, cfg *core.Config) (*core.L2ScannedBlock, e
 			db.Create(&l2ScannedBlock)
 		} else {
 			return nil, fmt.Errorf("failed to query l2_scanned_blocks: %w", result.Error)
-		}
-	} else {
-		if l2ScannedBlock.Number < cfg.Misc.ConfirmBlocks {
-			l2ScannedBlock.Number = 0
-		} else {
-			l2ScannedBlock.Number -= cfg.Misc.ConfirmBlocks
 		}
 	}
 	return &l2ScannedBlock, nil

--- a/core/client.go
+++ b/core/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -76,6 +77,18 @@ func (c *ClientExt) CallContract(ctx context.Context, call ethereum.CallMsg, blo
 	}
 
 	return hexutil.Decode(result)
+}
+
+// New methods by block tag
+
+func (c *ClientExt) GetHeaderByTag(ctx context.Context, blockTag string) (*types.Header, error) {
+	var result types.Header
+	err := c.Client.Client().CallContext(ctx, &result, "eth_getHeaderByNumber", blockTag)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
 }
 
 // Needed private utils from geth

--- a/core/config.go
+++ b/core/config.go
@@ -16,7 +16,6 @@ import (
 )
 
 const (
-	defaultConfirmBlocks       = 15
 	defaultLogFilterBlockRange = 100
 )
 
@@ -32,7 +31,6 @@ type MiscConfig struct {
 	L2StandardBridgeBot string `toml:"l2-standard-bridge-bot"`
 	ProposeTimeWindow   int64  `toml:"propose-time-window"`
 	ChallengeTimeWindow int64  `toml:"challenge-time-window"`
-	ConfirmBlocks       int64  `toml:"confirm-blocks"`
 	LogFilterBlockRange int64  `toml:"log-filter-block-range"`
 }
 
@@ -58,10 +56,6 @@ func LoadConfig(log log.Logger, path string) (Config, error) {
 		return conf, err
 	}
 
-	if conf.Misc.ConfirmBlocks == 0 {
-		log.Info("setting default confirm blocks", "confirm-blocks", defaultConfirmBlocks)
-		conf.Misc.ConfirmBlocks = defaultConfirmBlocks
-	}
 	if conf.Misc.LogFilterBlockRange == 0 {
 		log.Info("setting default log filter block range", "log-filter-block-range", defaultLogFilterBlockRange)
 		conf.Misc.LogFilterBlockRange = defaultLogFilterBlockRange


### PR DESCRIPTION
To eliminate the impact caused by l2-reorg, the l2-scanner choose to only scan the finalized blocks. Once a l2-block has been finalized, it can be confirmed that it will not be reorg.

Previously, we configured Misc.ConfirmBlocks to eliminate L2 reorg impact, but finalized block tags are more robust. So this PR removes Misc.ConfirmBlocks also.