### PR TITLE
[audit] fix: avoid reprocessing withdrawals

### DIFF
--- a/bindings/L2StandardBridgeBot.go
+++ b/bindings/L2StandardBridgeBot.go
@@ -31,7 +31,7 @@ var (
 
 // L2StandardBridgeBotMetaData contains all meta data concerning the L2StandardBridgeBot contract.
 var L2StandardBridgeBotMetaData = &bind.MetaData{
-	ABI: "[{\"inputs\":[{\"internalType\":\"addresspayable\",\"name\":\"_owner\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_delegationFee\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OwnableInvalidOwner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"OwnableUnauthorizedAccount\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"l2Token\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"minGasLimit\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"extraData\",\"type\":\"bytes\"}],\"name\":\"WithdrawTo\",\"type\":\"event\"},{\"stateMutability\":\"payable\",\"type\":\"fallback\"},{\"inputs\":[],\"name\":\"L2_STANDARD_BRIDGE\",\"outputs\":[{\"internalType\":\"contractIL2StandardBridge\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"L2_STANDARD_BRIDGE_ADDRESS\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"delegationFee\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_delegationFee\",\"type\":\"uint256\"}],\"name\":\"setDelegationFee\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_l2Token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_amount\",\"type\":\"uint256\"},{\"internalType\":\"uint32\",\"name\":\"_minGasLimit\",\"type\":\"uint32\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"withdraw\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_recipient\",\"type\":\"address\"}],\"name\":\"withdrawFee\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_recipient\",\"type\":\"address\"},{\"internalType\":\"uint32\",\"name\":\"_minGasLimit\",\"type\":\"uint32\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"withdrawFeeToL1\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_l2Token\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_amount\",\"type\":\"uint256\"},{\"internalType\":\"uint32\",\"name\":\"_minGasLimit\",\"type\":\"uint32\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"withdrawTo\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"stateMutability\":\"payable\",\"type\":\"receive\"}]",
+	ABI: "[{\"inputs\":[{\"internalType\":\"addresspayable\",\"name\":\"_owner\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_delegationFee\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"}],\"name\":\"AddressEmptyCode\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"AddressInsufficientBalance\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"FailedInnerCall\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OwnableInvalidOwner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"OwnableUnauthorizedAccount\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"}],\"name\":\"SafeERC20FailedOperation\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"_delegationFee\",\"type\":\"uint256\"}],\"name\":\"SetDelegationFee\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"l2Token\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"minGasLimit\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"extraData\",\"type\":\"bytes\"}],\"name\":\"WithdrawTo\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"L2_STANDARD_BRIDGE\",\"outputs\":[{\"internalType\":\"contractIL2StandardBridge\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"L2_STANDARD_BRIDGE_ADDRESS\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"delegationFee\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_delegationFee\",\"type\":\"uint256\"}],\"name\":\"setDelegationFee\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_l2Token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_amount\",\"type\":\"uint256\"},{\"internalType\":\"uint32\",\"name\":\"_minGasLimit\",\"type\":\"uint32\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"withdraw\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_recipient\",\"type\":\"address\"}],\"name\":\"withdrawFee\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_recipient\",\"type\":\"address\"},{\"internalType\":\"uint32\",\"name\":\"_minGasLimit\",\"type\":\"uint32\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"withdrawFeeToL1\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_l2Token\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_amount\",\"type\":\"uint256\"},{\"internalType\":\"uint32\",\"name\":\"_minGasLimit\",\"type\":\"uint32\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"withdrawTo\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"}]",
 }
 
 // L2StandardBridgeBotABI is the input ABI used to generate the binding from.
@@ -451,48 +451,6 @@ func (_L2StandardBridgeBot *L2StandardBridgeBotTransactorSession) WithdrawTo(_l2
 	return _L2StandardBridgeBot.Contract.WithdrawTo(&_L2StandardBridgeBot.TransactOpts, _l2Token, _to, _amount, _minGasLimit, _extraData)
 }
 
-// Fallback is a paid mutator transaction binding the contract fallback function.
-//
-// Solidity: fallback() payable returns()
-func (_L2StandardBridgeBot *L2StandardBridgeBotTransactor) Fallback(opts *bind.TransactOpts, calldata []byte) (*types.Transaction, error) {
-	return _L2StandardBridgeBot.contract.RawTransact(opts, calldata)
-}
-
-// Fallback is a paid mutator transaction binding the contract fallback function.
-//
-// Solidity: fallback() payable returns()
-func (_L2StandardBridgeBot *L2StandardBridgeBotSession) Fallback(calldata []byte) (*types.Transaction, error) {
-	return _L2StandardBridgeBot.Contract.Fallback(&_L2StandardBridgeBot.TransactOpts, calldata)
-}
-
-// Fallback is a paid mutator transaction binding the contract fallback function.
-//
-// Solidity: fallback() payable returns()
-func (_L2StandardBridgeBot *L2StandardBridgeBotTransactorSession) Fallback(calldata []byte) (*types.Transaction, error) {
-	return _L2StandardBridgeBot.Contract.Fallback(&_L2StandardBridgeBot.TransactOpts, calldata)
-}
-
-// Receive is a paid mutator transaction binding the contract receive function.
-//
-// Solidity: receive() payable returns()
-func (_L2StandardBridgeBot *L2StandardBridgeBotTransactor) Receive(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _L2StandardBridgeBot.contract.RawTransact(opts, nil) // calldata is disallowed for receive function
-}
-
-// Receive is a paid mutator transaction binding the contract receive function.
-//
-// Solidity: receive() payable returns()
-func (_L2StandardBridgeBot *L2StandardBridgeBotSession) Receive() (*types.Transaction, error) {
-	return _L2StandardBridgeBot.Contract.Receive(&_L2StandardBridgeBot.TransactOpts)
-}
-
-// Receive is a paid mutator transaction binding the contract receive function.
-//
-// Solidity: receive() payable returns()
-func (_L2StandardBridgeBot *L2StandardBridgeBotTransactorSession) Receive() (*types.Transaction, error) {
-	return _L2StandardBridgeBot.Contract.Receive(&_L2StandardBridgeBot.TransactOpts)
-}
-
 // L2StandardBridgeBotOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the L2StandardBridgeBot contract.
 type L2StandardBridgeBotOwnershipTransferredIterator struct {
 	Event *L2StandardBridgeBotOwnershipTransferred // Event containing the contract specifics and raw log
@@ -646,6 +604,140 @@ func (_L2StandardBridgeBot *L2StandardBridgeBotFilterer) ParseOwnershipTransferr
 	return event, nil
 }
 
+// L2StandardBridgeBotSetDelegationFeeIterator is returned from FilterSetDelegationFee and is used to iterate over the raw logs and unpacked data for SetDelegationFee events raised by the L2StandardBridgeBot contract.
+type L2StandardBridgeBotSetDelegationFeeIterator struct {
+	Event *L2StandardBridgeBotSetDelegationFee // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *L2StandardBridgeBotSetDelegationFeeIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(L2StandardBridgeBotSetDelegationFee)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(L2StandardBridgeBotSetDelegationFee)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *L2StandardBridgeBotSetDelegationFeeIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *L2StandardBridgeBotSetDelegationFeeIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// L2StandardBridgeBotSetDelegationFee represents a SetDelegationFee event raised by the L2StandardBridgeBot contract.
+type L2StandardBridgeBotSetDelegationFee struct {
+	DelegationFee *big.Int
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterSetDelegationFee is a free log retrieval operation binding the contract event 0x0322f3257c2afe5fe8da7ab561f0d3384148487412fe2751678f2188731c0815.
+//
+// Solidity: event SetDelegationFee(uint256 _delegationFee)
+func (_L2StandardBridgeBot *L2StandardBridgeBotFilterer) FilterSetDelegationFee(opts *bind.FilterOpts) (*L2StandardBridgeBotSetDelegationFeeIterator, error) {
+
+	logs, sub, err := _L2StandardBridgeBot.contract.FilterLogs(opts, "SetDelegationFee")
+	if err != nil {
+		return nil, err
+	}
+	return &L2StandardBridgeBotSetDelegationFeeIterator{contract: _L2StandardBridgeBot.contract, event: "SetDelegationFee", logs: logs, sub: sub}, nil
+}
+
+// WatchSetDelegationFee is a free log subscription operation binding the contract event 0x0322f3257c2afe5fe8da7ab561f0d3384148487412fe2751678f2188731c0815.
+//
+// Solidity: event SetDelegationFee(uint256 _delegationFee)
+func (_L2StandardBridgeBot *L2StandardBridgeBotFilterer) WatchSetDelegationFee(opts *bind.WatchOpts, sink chan<- *L2StandardBridgeBotSetDelegationFee) (event.Subscription, error) {
+
+	logs, sub, err := _L2StandardBridgeBot.contract.WatchLogs(opts, "SetDelegationFee")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(L2StandardBridgeBotSetDelegationFee)
+				if err := _L2StandardBridgeBot.contract.UnpackLog(event, "SetDelegationFee", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSetDelegationFee is a log parse operation binding the contract event 0x0322f3257c2afe5fe8da7ab561f0d3384148487412fe2751678f2188731c0815.
+//
+// Solidity: event SetDelegationFee(uint256 _delegationFee)
+func (_L2StandardBridgeBot *L2StandardBridgeBotFilterer) ParseSetDelegationFee(log types.Log) (*L2StandardBridgeBotSetDelegationFee, error) {
+	event := new(L2StandardBridgeBotSetDelegationFee)
+	if err := _L2StandardBridgeBot.contract.UnpackLog(event, "SetDelegationFee", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
 // L2StandardBridgeBotWithdrawToIterator is returned from FilterWithdrawTo and is used to iterate over the raw logs and unpacked data for WithdrawTo events raised by the L2StandardBridgeBot contract.
 type L2StandardBridgeBotWithdrawToIterator struct {
 	Event *L2StandardBridgeBotWithdrawTo // Event containing the contract specifics and raw log
@@ -726,15 +818,19 @@ type L2StandardBridgeBotWithdrawTo struct {
 
 // FilterWithdrawTo is a free log retrieval operation binding the contract event 0x56f66275d9ebc94b7d6895aa0d96a3783550d0183ba106408d387d19f2e877f1.
 //
-// Solidity: event WithdrawTo(address indexed from, address l2Token, address to, uint256 amount, uint32 minGasLimit, bytes extraData)
-func (_L2StandardBridgeBot *L2StandardBridgeBotFilterer) FilterWithdrawTo(opts *bind.FilterOpts, from []common.Address) (*L2StandardBridgeBotWithdrawToIterator, error) {
+// Solidity: event WithdrawTo(address indexed from, address indexed l2Token, address to, uint256 amount, uint32 minGasLimit, bytes extraData)
+func (_L2StandardBridgeBot *L2StandardBridgeBotFilterer) FilterWithdrawTo(opts *bind.FilterOpts, from []common.Address, l2Token []common.Address) (*L2StandardBridgeBotWithdrawToIterator, error) {
 
 	var fromRule []interface{}
 	for _, fromItem := range from {
 		fromRule = append(fromRule, fromItem)
 	}
+	var l2TokenRule []interface{}
+	for _, l2TokenItem := range l2Token {
+		l2TokenRule = append(l2TokenRule, l2TokenItem)
+	}
 
-	logs, sub, err := _L2StandardBridgeBot.contract.FilterLogs(opts, "WithdrawTo", fromRule)
+	logs, sub, err := _L2StandardBridgeBot.contract.FilterLogs(opts, "WithdrawTo", fromRule, l2TokenRule)
 	if err != nil {
 		return nil, err
 	}
@@ -743,15 +839,19 @@ func (_L2StandardBridgeBot *L2StandardBridgeBotFilterer) FilterWithdrawTo(opts *
 
 // WatchWithdrawTo is a free log subscription operation binding the contract event 0x56f66275d9ebc94b7d6895aa0d96a3783550d0183ba106408d387d19f2e877f1.
 //
-// Solidity: event WithdrawTo(address indexed from, address l2Token, address to, uint256 amount, uint32 minGasLimit, bytes extraData)
-func (_L2StandardBridgeBot *L2StandardBridgeBotFilterer) WatchWithdrawTo(opts *bind.WatchOpts, sink chan<- *L2StandardBridgeBotWithdrawTo, from []common.Address) (event.Subscription, error) {
+// Solidity: event WithdrawTo(address indexed from, address indexed l2Token, address to, uint256 amount, uint32 minGasLimit, bytes extraData)
+func (_L2StandardBridgeBot *L2StandardBridgeBotFilterer) WatchWithdrawTo(opts *bind.WatchOpts, sink chan<- *L2StandardBridgeBotWithdrawTo, from []common.Address, l2Token []common.Address) (event.Subscription, error) {
 
 	var fromRule []interface{}
 	for _, fromItem := range from {
 		fromRule = append(fromRule, fromItem)
 	}
+	var l2TokenRule []interface{}
+	for _, l2TokenItem := range l2Token {
+		l2TokenRule = append(l2TokenRule, l2TokenItem)
+	}
 
-	logs, sub, err := _L2StandardBridgeBot.contract.WatchLogs(opts, "WithdrawTo", fromRule)
+	logs, sub, err := _L2StandardBridgeBot.contract.WatchLogs(opts, "WithdrawTo", fromRule, l2TokenRule)
 	if err != nil {
 		return nil, err
 	}
@@ -785,7 +885,7 @@ func (_L2StandardBridgeBot *L2StandardBridgeBotFilterer) WatchWithdrawTo(opts *b
 
 // ParseWithdrawTo is a log parse operation binding the contract event 0x56f66275d9ebc94b7d6895aa0d96a3783550d0183ba106408d387d19f2e877f1.
 //
-// Solidity: event WithdrawTo(address indexed from, address l2Token, address to, uint256 amount, uint32 minGasLimit, bytes extraData)
+// Solidity: event WithdrawTo(address indexed from, address indexed l2Token, address to, uint256 amount, uint32 minGasLimit, bytes extraData)
 func (_L2StandardBridgeBot *L2StandardBridgeBotFilterer) ParseWithdrawTo(log types.Log) (*L2StandardBridgeBotWithdrawTo, error) {
 	event := new(L2StandardBridgeBotWithdrawTo)
 	if err := _L2StandardBridgeBot.contract.UnpackLog(event, "WithdrawTo", log); err != nil {

--- a/bot.testnet.toml
+++ b/bot.testnet.toml
@@ -23,7 +23,7 @@ l2-output-oracle                = "0xff2394bb843012562f4349c6632a0ecb92fc8810"
 l1-cross-domain-messenger       = "0xd506952e78eecd5d4424b1990a0c99b1568e7c2c"
 
 [l2-standard-bridge-bot]
-contract-address                = "0x62fa6549e240076D466E1150ce587905c55f12F1"
+contract-address                = "$OPBNB_BRIDGE_BOT_L2_STANDARD_BRIDGE_BOT_CONTRACT_ADDRESS"
 log-filter-block-range = 1000
 
 # See https://github.com/bnb-chain/opbnb-bridge-tokens#opbnb-testnet-token-list

--- a/bot.testnet.toml
+++ b/bot.testnet.toml
@@ -23,7 +23,7 @@ l2-output-oracle                = "0xff2394bb843012562f4349c6632a0ecb92fc8810"
 l1-cross-domain-messenger       = "0xd506952e78eecd5d4424b1990a0c99b1568e7c2c"
 
 [l2-standard-bridge-bot]
-contract-address                = "$OPBNB_BRIDGE_BOT_L2_STANDARD_BRIDGE_BOT_CONTRACT_ADDRESS"
+contract-address                = "0xE750d1f9180294473baCd960Ce5F9576eFBd70f2"
 log-filter-block-range = 1000
 
 # See https://github.com/bnb-chain/opbnb-bridge-tokens#opbnb-testnet-token-list

--- a/cmd/bot/run.go
+++ b/cmd/bot/run.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/lru"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/urfave/cli/v2"
@@ -76,18 +77,32 @@ func RunCommand(ctx *cli.Context) error {
 // and it will finalize the withdrawal when the challenge time window has passed.
 func ProcessBotDelegatedWithdrawals(ctx context.Context, log log.Logger, db *gorm.DB, l1Client *core.ClientExt, l2Client *core.ClientExt, cfg core.Config) {
 	ticker := time.NewTicker(3 * time.Second)
+	unprovenTombstone := lru.NewCache[uint, time.Time](10000)
+	unfinalizedTombstone := lru.NewCache[uint, time.Time](10000)
 	for {
 		select {
 		case <-ticker.C:
-			ProcessUnprovenBotDelegatedWithdrawals(ctx, log, db, l1Client, l2Client, cfg)
-			ProcessUnfinalizedBotDelegatedWithdrawals(ctx, log, db, l1Client, l2Client, cfg)
+			// In order to avoid re-processing the same withdrawal, we need to check if the pending nonce is
+			// the chain nonce. If they are not equal, it means that there are some pending transactions that
+			// been confirmed yet.
+			_, signerAddress, _ := cfg.SignerKeyPair()
+			if equal, err := isPendingAndChainNonceEqual(l1Client, signerAddress); err != nil {
+				log.Error("failed to check pending and chain nonce", "error", err)
+				continue
+			} else if !equal {
+				log.Info("pending nonce is not equal to chain nonce, skip processing")
+				continue
+			}
+
+			ProcessUnprovenBotDelegatedWithdrawals(ctx, log, db, l1Client, l2Client, cfg, unprovenTombstone)
+			ProcessUnfinalizedBotDelegatedWithdrawals(ctx, log, db, l1Client, l2Client, cfg, unfinalizedTombstone)
 		case <-ctx.Done():
 			return
 		}
 	}
 }
 
-func ProcessUnprovenBotDelegatedWithdrawals(ctx context.Context, log log.Logger, db *gorm.DB, l1Client *core.ClientExt, l2Client *core.ClientExt, cfg core.Config) {
+func ProcessUnprovenBotDelegatedWithdrawals(ctx context.Context, log log.Logger, db *gorm.DB, l1Client *core.ClientExt, l2Client *core.ClientExt, cfg core.Config, tombstone *lru.Cache[uint, time.Time]) {
 	processor := core.NewProcessor(log, l1Client, l2Client, cfg)
 	limit := 1000
 	maxBlockTime := time.Now().Unix() - cfg.ProposeTimeWindow
@@ -100,6 +115,11 @@ func ProcessUnprovenBotDelegatedWithdrawals(ctx context.Context, log log.Logger,
 	}
 
 	for _, unproven := range unprovens {
+		// In order to avoid re-processing the same withdrawal, we use a tombstone to mark the withdrawal as processed.
+		if hasWithdrawalRecentlyProcessed(&unproven, tombstone) {
+			continue
+		}
+
 		err := processor.ProveWithdrawalTransaction(ctx, &unproven)
 		if err != nil {
 			if strings.Contains(err.Error(), "OptimismPortal: withdrawal hash has already been proven") {
@@ -123,11 +143,13 @@ func ProcessUnprovenBotDelegatedWithdrawals(ctx context.Context, log log.Logger,
 				log.Error("ProveWithdrawalTransaction", "non-revert error", err.Error())
 				return
 			}
+		} else {
+			markWithdrawalAsProcessed(&unproven, tombstone)
 		}
 	}
 }
 
-func ProcessUnfinalizedBotDelegatedWithdrawals(ctx context.Context, log log.Logger, db *gorm.DB, l1Client *core.ClientExt, l2Client *core.ClientExt, cfg core.Config) {
+func ProcessUnfinalizedBotDelegatedWithdrawals(ctx context.Context, log log.Logger, db *gorm.DB, l1Client *core.ClientExt, l2Client *core.ClientExt, cfg core.Config, tombstone *lru.Cache[uint, time.Time]) {
 	processor := core.NewProcessor(log, l1Client, l2Client, cfg)
 	limit := 1000
 	maxBlockTime := time.Now().Unix() - cfg.ChallengeTimeWindow
@@ -140,6 +162,11 @@ func ProcessUnfinalizedBotDelegatedWithdrawals(ctx context.Context, log log.Logg
 	}
 
 	for _, unfinalized := range unfinalizeds {
+		// In order to avoid re-processing the same withdrawal, we use a tombstone to mark the withdrawal as processed.
+		if hasWithdrawalRecentlyProcessed(&unfinalized, tombstone) {
+			continue
+		}
+
 		err := processor.FinalizeMessage(ctx, &unfinalized)
 		if err != nil {
 			if strings.Contains(err.Error(), "OptimismPortal: withdrawal has already been finalized") {
@@ -165,6 +192,8 @@ func ProcessUnfinalizedBotDelegatedWithdrawals(ctx context.Context, log log.Logg
 				log.Error("FinalizedMessage", "non-revert error", err.Error())
 				return
 			}
+		} else {
+			markWithdrawalAsProcessed(&unfinalized, tombstone)
 		}
 	}
 }
@@ -307,4 +336,31 @@ func queryL2ScannedBlock(db *gorm.DB, l2StartingNumber int64) (*core.L2ScannedBl
 		}
 	}
 	return &l2ScannedBlock, nil
+}
+
+// hasWithdrawalRecentlyProcessed checks if the withdrawal has been processed recently.
+func hasWithdrawalRecentlyProcessed(botDelegatedWithdrawal *core.L2ContractEvent, tombstone *lru.Cache[uint, time.Time]) bool {
+	const tombstoneTTL = 10 * time.Minute
+	timestamp, ok := tombstone.Get(botDelegatedWithdrawal.ID)
+	return ok && timestamp.After(time.Now().Add(-tombstoneTTL))
+}
+
+// markWithdrawalAsProcessed marks the withdrawal as processed.
+func markWithdrawalAsProcessed(botDelegatedWithdrawal *core.L2ContractEvent, tombstone *lru.Cache[uint, time.Time]) {
+	tombstone.Add(botDelegatedWithdrawal.ID, time.Now())
+}
+
+// isPendingAndChainNonceEqual checks if the pending nonce and the chain nonce are equal.
+func isPendingAndChainNonceEqual(l1Client *core.ClientExt, address *common.Address) (bool, error) {
+	pendingNonce, err := l1Client.PendingNonceAt(context.Background(), *address)
+	if err != nil {
+		return false, fmt.Errorf("failed to get pending nonce: %w", err)
+	}
+
+	latestNonce, err := l1Client.NonceAt(context.Background(), *address, nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to get latest nonce: %w", err)
+	}
+
+	return pendingNonce == latestNonce, nil
 }

--- a/cmd/bot/run.go
+++ b/cmd/bot/run.go
@@ -103,12 +103,17 @@ func ProcessBotDelegatedWithdrawals(ctx context.Context, log log.Logger, db *gor
 }
 
 func ProcessUnprovenBotDelegatedWithdrawals(ctx context.Context, log log.Logger, db *gorm.DB, l1Client *core.ClientExt, l2Client *core.ClientExt, cfg core.Config, tombstone *lru.Cache[uint, time.Time]) {
+	latestProposedNumber, err := core.L2OutputOracleLatestBlockNumber(cfg.L1Contracts.L2OutputOracleProxy, l1Client)
+	if err != nil {
+		log.Error("failed to get latest proposed block number", "error", err)
+		return
+	}
+
 	processor := core.NewProcessor(log, l1Client, l2Client, cfg)
 	limit := 1000
-	maxBlockTime := time.Now().Unix() - cfg.ProposeTimeWindow
 
 	unprovens := make([]core.BotDelegatedWithdrawal, 0)
-	result := db.Order("id asc").Where("proven = false AND block_time < ? AND failure_reason IS NULL", maxBlockTime).Limit(limit).Find(&unprovens)
+	result := db.Order("id asc").Where("proven_time IS NULL AND initiated_block_number <= ? AND failure_reason IS NULL", latestProposedNumber.Uint64()).Limit(limit).Find(&unprovens)
 	if result.Error != nil {
 		log.Error("failed to query withdrawals", "error", result.Error)
 		return
@@ -120,11 +125,12 @@ func ProcessUnprovenBotDelegatedWithdrawals(ctx context.Context, log log.Logger,
 			continue
 		}
 
+		now := time.Now()
 		err := processor.ProveWithdrawalTransaction(ctx, &unproven)
 		if err != nil {
 			if strings.Contains(err.Error(), "OptimismPortal: withdrawal hash has already been proven") {
 				// The withdrawal has already proven, mark it
-				result := db.Model(&unproven).Update("proven", true)
+				result := db.Model(&unproven).Update("proven_time", now)
 				if result.Error != nil {
 					log.Error("failed to update proven withdrawals", "error", result.Error)
 				}
@@ -152,10 +158,12 @@ func ProcessUnprovenBotDelegatedWithdrawals(ctx context.Context, log log.Logger,
 func ProcessUnfinalizedBotDelegatedWithdrawals(ctx context.Context, log log.Logger, db *gorm.DB, l1Client *core.ClientExt, l2Client *core.ClientExt, cfg core.Config, tombstone *lru.Cache[uint, time.Time]) {
 	processor := core.NewProcessor(log, l1Client, l2Client, cfg)
 	limit := 1000
-	maxBlockTime := time.Now().Unix() - cfg.ChallengeTimeWindow
+
+	now := time.Now()
+	maxProvenTime := now.Add(-time.Duration(cfg.Misc.ChallengeTimeWindow) * time.Second)
 
 	unfinalizeds := make([]core.BotDelegatedWithdrawal, 0)
-	result := db.Order("block_time asc").Where("proven = true AND finalized = false AND block_time < ? AND failure_reason IS NULL", maxBlockTime).Limit(limit).Find(&unfinalizeds)
+	result := db.Order("id asc").Where("finalized_time IS NULL AND proven_time IS NOT NULL AND proven_time < ? AND failure_reason IS NULL", maxProvenTime).Limit(limit).Find(&unfinalizeds)
 	if result.Error != nil {
 		log.Error("failed to query withdrawals", "error", result.Error)
 		return
@@ -171,7 +179,7 @@ func ProcessUnfinalizedBotDelegatedWithdrawals(ctx context.Context, log log.Logg
 		if err != nil {
 			if strings.Contains(err.Error(), "OptimismPortal: withdrawal has already been finalized") {
 				// The withdrawal has already finalized, mark it
-				result := db.Model(&unfinalized).Update("finalized", true)
+				result := db.Model(&unfinalized).Update("finalized_time", now)
 				if result.Error != nil {
 					log.Error("failed to update finalized withdrawals", "error", result.Error)
 				}
@@ -208,12 +216,9 @@ func storeLogs(db *gorm.DB, client *core.ClientExt, logs []types.Log) error {
 		}
 
 		event := core.BotDelegatedWithdrawal{
-			BlockTime:       int64(header.Time),
-			BlockHash:       vLog.BlockHash.Hex(),
-			ContractAddress: vLog.Address.Hex(),
-			TransactionHash: vLog.TxHash.Hex(),
-			LogIndex:        int(vLog.Index),
-			EventSignature:  vLog.Topics[0].Hex(),
+			TransactionHash:      vLog.TxHash.Hex(),
+			LogIndex:             int(vLog.Index),
+			InitiatedBlockNumber: int64(header.Number.Uint64()),
 		}
 
 		deduped := db.Clauses(
@@ -229,9 +234,9 @@ func storeLogs(db *gorm.DB, client *core.ClientExt, logs []types.Log) error {
 }
 
 // WatchBotDelegatedWithdrawals watches for new bot-delegated withdrawals and stores them in the database.
-func WatchBotDelegatedWithdrawals(ctx context.Context, log log.Logger, db *gorm.DB, client *core.ClientExt, l2ScannedBlock *core.L2ScannedBlock, cfg core.Config) {
+func WatchBotDelegatedWithdrawals(ctx context.Context, log log.Logger, db *gorm.DB, client *core.ClientExt, l2StartingBlock *core.L2ScannedBlock, cfg core.Config) {
 	timer := time.NewTimer(0)
-	fromBlockNumber := big.NewInt(l2ScannedBlock.Number)
+	fromBlockNumber := big.NewInt(l2StartingBlock.Number)
 
 	for {
 		select {
@@ -275,8 +280,8 @@ func WatchBotDelegatedWithdrawals(ctx context.Context, log log.Logger, db *gorm.
 			}
 		}
 
-		l2ScannedBlock.Number = toBlockNumber.Int64()
-		result := db.Where("number >= 0").Updates(l2ScannedBlock)
+		l2StartingBlock.Number = toBlockNumber.Int64()
+		result := db.Where("number >= 0").Updates(l2StartingBlock)
 		if result.Error != nil {
 			log.Error("update l2_scanned_blocks", "error", result.Error)
 		}

--- a/core/bindings.go
+++ b/core/bindings.go
@@ -1,6 +1,9 @@
 package core
 
 import (
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum/go-ethereum/common"
 	"golang.org/x/crypto/sha3"
 )
@@ -16,4 +19,14 @@ func WithdrawToEventSig() common.Hash {
 	keccak256.Write([]byte(eventSignature))
 	eventSignatureHash := keccak256.Sum(nil)
 	return common.BytesToHash(eventSignatureHash)
+}
+
+// L2OutputOracleLatestBlockNumber calls the "latestBlockNumber" function on the L2OutputOracle contract at the given address.
+func L2OutputOracleLatestBlockNumber(address common.Address, l1Client *ClientExt) (*big.Int, error) {
+	caller, err := bindings.NewL2OutputOracleCaller(address, l1Client)
+	if err != nil {
+		return nil, err
+	}
+
+	return caller.LatestBlockNumber(nil)
 }

--- a/core/pending_txn_check.go
+++ b/core/pending_txn_check.go
@@ -1,0 +1,30 @@
+package core
+
+type PendingTxnCheck struct {
+	inner map[uint]uint64 // #{withdrawalId=>nonce}
+}
+
+// NewPendingTxsManager creates a new PendingTxnCheck
+func NewPendingTxsManager() *PendingTxnCheck {
+	return &PendingTxnCheck{inner: make(map[uint]uint64)}
+}
+
+// IsPendingTxn checks whether there is pending transaction for the specific event id.
+func (c *PendingTxnCheck) IsPendingTxn(id uint) bool {
+	_, ok := c.inner[id]
+	return ok
+}
+
+// AddPendingTxn adds a pending item.
+func (c *PendingTxnCheck) AddPendingTxn(id uint, nonce uint64) {
+	c.inner[id] = nonce
+}
+
+// Prune removes the transactions with staled nonce.
+func (c *PendingTxnCheck) Prune(chainNonce uint64) {
+	for id, nonce := range c.inner {
+		if nonce <= chainNonce {
+			delete(c.inner, id)
+		}
+	}
+}

--- a/core/processor.go
+++ b/core/processor.go
@@ -82,7 +82,7 @@ func (b *Processor) toWithdrawal(botDelegatedWithdrawToEvent *BotDelegatedWithdr
 	return withdrawalTx, nil
 }
 
-func (b *Processor) ProveWithdrawalTransaction(ctx context.Context, botDelegatedWithdrawToEvent *BotDelegatedWithdrawal) error {
+func (b *Processor) ProveWithdrawalTransaction(ctx context.Context, botDelegatedWithdrawToEvent *BotDelegatedWithdrawal, nonce uint64) error {
 	receipt, err := b.L2Client.TransactionReceipt(ctx, common.HexToHash(botDelegatedWithdrawToEvent.TransactionHash))
 	if err != nil {
 		return err
@@ -170,6 +170,7 @@ func (b *Processor) ProveWithdrawalTransaction(ctx context.Context, botDelegated
 			Signer: func(address common.Address, tx *types.Transaction) (*types.Transaction, error) {
 				return types.SignTx(tx, types.NewEIP155Signer(l1ChainId), signerPrivkey)
 			},
+			Nonce: big.NewInt(int64(nonce)),
 		},
 		*withdrawalTx,
 		l2OutputIndex,
@@ -529,7 +530,7 @@ func (b *Processor) toLowLevelMessage(
 	return &withdrawalTx, nil
 }
 
-func (b *Processor) CheckByFilterOptions(botDelegatedWithdrawToEvent *L2ContractEvent, receipt *types.Receipt) error {
+func (b *Processor) CheckByFilterOptions(botDelegatedWithdrawToEvent *BotDelegatedWithdrawal, receipt *types.Receipt) error {
 	L2StandardBridgeBotAbi, _ := bindings2.L2StandardBridgeBotMetaData.GetAbi()
 	withdrawToEvent := bindings2.L2StandardBridgeBotWithdrawTo{}
 	indexedArgs := func(arguments abi.Arguments) abi.Arguments {

--- a/core/processor.go
+++ b/core/processor.go
@@ -48,7 +48,7 @@ func NewProcessor(
 	return &Processor{log, l1Client, l2Client, cfg, l2Contracts, whitelistL2TokenMap}
 }
 
-func (b *Processor) toWithdrawal(botDelegatedWithdrawToEvent *L2ContractEvent, receipt *types.Receipt) (*bindings.TypesWithdrawalTransaction, error) {
+func (b *Processor) toWithdrawal(botDelegatedWithdrawToEvent *BotDelegatedWithdrawal, receipt *types.Receipt) (*bindings.TypesWithdrawalTransaction, error) {
 	// Events flow:
 	//
 	// event[i-5]: WithdrawalInitiated
@@ -82,7 +82,7 @@ func (b *Processor) toWithdrawal(botDelegatedWithdrawToEvent *L2ContractEvent, r
 	return withdrawalTx, nil
 }
 
-func (b *Processor) ProveWithdrawalTransaction(ctx context.Context, botDelegatedWithdrawToEvent *L2ContractEvent) error {
+func (b *Processor) ProveWithdrawalTransaction(ctx context.Context, botDelegatedWithdrawToEvent *BotDelegatedWithdrawal) error {
 	receipt, err := b.L2Client.TransactionReceipt(ctx, common.HexToHash(botDelegatedWithdrawToEvent.TransactionHash))
 	if err != nil {
 		return err
@@ -185,7 +185,7 @@ func (b *Processor) ProveWithdrawalTransaction(ctx context.Context, botDelegated
 }
 
 // FinalizeMessage https://github.com/ethereum-optimism/optimism/blob/d90e7818de894f0bc93ae7b449b9049416bda370/packages/sdk/src/cross-chain-messenger.ts#L1611
-func (b *Processor) FinalizeMessage(ctx context.Context, botDelegatedWithdrawToEvent *L2ContractEvent) error {
+func (b *Processor) FinalizeMessage(ctx context.Context, botDelegatedWithdrawToEvent *BotDelegatedWithdrawal) error {
 	receipt, err := b.L2Client.TransactionReceipt(ctx, common.HexToHash(botDelegatedWithdrawToEvent.TransactionHash))
 	if err != nil {
 		return err

--- a/core/types.go
+++ b/core/types.go
@@ -1,18 +1,28 @@
 package core
 
+import "time"
+
 type L2ScannedBlock struct {
 	Number int64 `gorm:"type:integer;primarykey"`
 }
 
-type L2ContractEvent struct {
-	ID              uint   `gorm:"primarykey"`
-	BlockTime       int64  `gorm:"type:integer;not null;index:idx_l2_contract_events_block_time"`
-	BlockHash       string `gorm:"type:varchar(256);not null;uniqueIndex:idx_l2_contract_events_block_hash_log_index_key,priority:1;"`
-	ContractAddress string `gorm:"type:varchar(256);not null"`
-	TransactionHash string `gorm:"type:varchar(256);not null"`
-	LogIndex        int    `gorm:"type:integer;not null;uniqueIndex:idx_l2_contract_events_block_hash_log_index_key,priority:2"`
-	EventSignature  string `gorm:"type:varchar(256);not null"`
-	Proven          bool   `gorm:"type:boolean;not null;default:false"`
-	Finalized       bool   `gorm:"type:boolean;not null;default:false"`
-	FailureReason   string `gorm:"type:text"`
+type BotDelegatedWithdrawal struct {
+	// ID is the incrementing primary key.
+	ID uint `gorm:"primarykey"`
+
+	// TransactionHash and LogIndex are the L2 transaction hash and log index of the withdrawal event.
+	TransactionHash string `gorm:"type:varchar(256);not null;uniqueIndex:idx_bot_delegated_withdrawals_transaction_hash_log_index_key,priority:1"`
+	LogIndex        int    `gorm:"type:integer;not null;uniqueIndex:idx_bot_delegated_withdrawals_transaction_hash_log_index_key,priority:2"`
+
+	// InitiatedBlockNumber is the l2 block number at which the withdrawal was initiated on L2.
+	InitiatedBlockNumber int64 `gorm:"type:integer;not null;index:idx_withdrawals_initiated_block_number"`
+
+	// ProvenTime is the local time at which the withdrawal was proven on L1. NULL if not yet proven.
+	ProvenTime *time.Time `gorm:"type:datetime;index:idx_withdrawals_proven_time"`
+
+	// FinalizedTime is the local time at which the withdrawal was finalized on L1. NULL if not yet finalized.
+	FinalizedTime *time.Time `gorm:"type:datetime;index:idx_withdrawals_finalized_time"`
+
+	// FailureReason is the reason for the withdrawal failure, including sending transaction error and off-chain configured filter error. NULL if not yet failed.
+	FailureReason *string `gorm:"type:text"`
 }


### PR DESCRIPTION


This PR introduces additional checks to prevent redundant processing of withdrawTo transactions in the ProcessBotDelegatedWithdrawals function.

1. We now compare the chain nonce with the pending nonce prior to processing. A discrepancy implies existence of transactions from the same address currently in the node’s tx-pool. Therefore, processing is deferred until the chain and pending nonces match, circumventing unnecessary reprocessing of already proven or finalized withdrawals.
2. A local LRU table is implemented as a tombstone, storing recently processed transactions timestamp. For each transaction, we check if it was processed within the past 5 minutes. If this is true, the transaction is skipped.

Implementing these checks enhances our code efficiency and reduces the risk of errors derived from reprocessing transactions
