### PR TITLE
[audit.l03] Index The `L2Token` in the `WithdrawTo` event

### DIFF
--- a/contracts/src/L2StandardBridgeBot.sol
+++ b/contracts/src/L2StandardBridgeBot.sol
@@ -25,7 +25,7 @@ contract L2StandardBridgeBot is Ownable {
 
     uint256 public delegationFee;
 
-    event WithdrawTo(address indexed from, address l2Token, address to, uint256 amount, uint32 minGasLimit, bytes extraData);
+    event WithdrawTo(address indexed from, address indexed l2Token, address to, uint256 amount, uint32 minGasLimit, bytes extraData);
 
     constructor(address payable _owner, uint256 _delegationFee) Ownable(_owner) {
         delegationFee = _delegationFee;

--- a/contracts/test/L2StandardBridgeBot.t.sol
+++ b/contracts/test/L2StandardBridgeBot.t.sol
@@ -15,7 +15,7 @@ contract L2StandardBridgeBotTest is Test {
     address constant LEGACY_ERC20_ETH = 0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000;
     address constant L2_STANDARD_BRIDGE = 0x4200000000000000000000000000000000000010;
 
-    event WithdrawTo(address indexed from, address l2Token, address to, uint256 amount, uint32 minGasLimit, bytes extraData);
+    event WithdrawTo(address indexed from, address indexed l2Token, address to, uint256 amount, uint32 minGasLimit, bytes extraData);
 
     event SentMessageExtension1(address indexed sender , uint256 value);
 


### PR DESCRIPTION
For improved search-ability, in the WithdrawTo event, the l2Token parameter should be `indexed`. When parameters are `indexed`, they create a search-able index of the data. This feature helps users or external entities to find specific events that happened on the blockchain more efficiently, using the `indexed` parameter as a filter.