### PR TITLE
fix: dont solely depend on the information from the L1 client to predict whether the transaction is committed

### DIFF
--- a/core/pending_txn_check.go
+++ b/core/pending_txn_check.go
@@ -1,12 +1,22 @@
 package core
 
+import "time"
+
+// txNonceAndTimestamp represents the nonce and sending timestamp of transaction.
+type txNonceAndTimestamp struct {
+	nonce     uint64
+	timestamp time.Time
+}
+
+// PendingTxnCheck records the nonce and sending timestamp of transactions, in order to prevent re-processing
+// the same withdrawals.
 type PendingTxnCheck struct {
-	inner map[uint]uint64 // #{withdrawalId=>nonce}
+	inner map[uint]txNonceAndTimestamp // #{withdrawalId=>txNonceAndTimestamp}
 }
 
 // NewPendingTxsManager creates a new PendingTxnCheck
 func NewPendingTxsManager() *PendingTxnCheck {
-	return &PendingTxnCheck{inner: make(map[uint]uint64)}
+	return &PendingTxnCheck{inner: make(map[uint]txNonceAndTimestamp)}
 }
 
 // IsPendingTxn checks whether there is pending transaction for the specific event id.
@@ -17,13 +27,16 @@ func (c *PendingTxnCheck) IsPendingTxn(id uint) bool {
 
 // AddPendingTxn adds a pending item.
 func (c *PendingTxnCheck) AddPendingTxn(id uint, nonce uint64) {
-	c.inner[id] = nonce
+	c.inner[id] = txNonceAndTimestamp{nonce: nonce, timestamp: time.Now()}
 }
 
-// Prune removes the transactions with staled nonce.
+// Prune removes the transactions with chainNonce and the current timestamp.
 func (c *PendingTxnCheck) Prune(chainNonce uint64) {
-	for id, nonce := range c.inner {
-		if nonce <= chainNonce {
+	const DurationSafelyPrunePendingTxs = 5 * time.Minute
+	timeSafelyPrunePendingTxs := time.Now().Add(-1 * DurationSafelyPrunePendingTxs)
+
+	for id, nt := range c.inner {
+		if nt.nonce <= chainNonce && nt.timestamp.Before(timeSafelyPrunePendingTxs) {
 			delete(c.inner, id)
 		}
 	}


### PR DESCRIPTION
Based on the observation of testnet, MegaNode may have such a problem:

- `eth_getTransactionsCount`'s base on block height of `X`

- `eth_estimateGas`'s base block height is `X-1`

As a result of the inconsistent performance of different interfaces, we are not able to simply determine whether a withdrawal has been processed by using a nonce check.

The PR adds a local timestamp check for fault tolerance.